### PR TITLE
Fixed NetworkX Graph attribute 'node[]' occurrences to 'nodes[]'

### DIFF
--- a/demon/alg/Demon.py
+++ b/demon/alg/Demon.py
@@ -79,7 +79,7 @@ class Demon(object):
         """
 
         for n in self.g.nodes():
-            self.g.node[n]['communities'] = [n]
+            self.g.nodes[n]['communities'] = [n]
 
         all_communities = {}
 
@@ -151,7 +151,7 @@ class Demon(object):
                 if t == 1:
                     if not len(n_neighbors) == 0:
                         r_label = random.sample(label_freq.keys(), 1)
-                        ego_minus_ego.node[n]['communities'] = r_label
+                        ego_minus_ego.nodes[n]['communities'] = r_label
                         old_node_to_coms[n] = r_label
                     count += 1
                     continue
@@ -172,15 +172,15 @@ class Demon(object):
 
                     if n not in old_node_to_coms or not set(node_to_coms[n]) == set(old_node_to_coms[n]):
                         old_node_to_coms[n] = node_to_coms[n]
-                        ego_minus_ego.node[n]['communities'] = labels
+                        ego_minus_ego.nodes[n]['communities'] = labels
 
         # build the communities reintroducing the ego
         community_to_nodes = {}
         for n in nx.nodes(ego_minus_ego):
             if len(list(nx.neighbors(ego_minus_ego, n))) == 0:
-                ego_minus_ego.node[n]['communities'] = [n]
+                ego_minus_ego.nodes[n]['communities'] = [n]
 
-            c_n = ego_minus_ego.node[n]['communities']
+            c_n = ego_minus_ego.nodes[n]['communities']
 
             for c in c_n:
 


### PR DESCRIPTION
Graph attribute 'G.node' was removed in NetworkX 2.4, and has moved its functionality to 'G.nodes' .
G.nodes will work on all NetworkX 2.x versions, but not on NetworkX 1.x.